### PR TITLE
Accepts coordinate pairs and retains non-overriden opts ( no tests )

### DIFF
--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -17,12 +17,19 @@ class GoogleDirections
     :sensor => :false,
     :mode => :driving,
   }
-
+  
   def initialize(origin, destination, opts=@@default_options)
     @origin = origin
     @destination = destination
-    @options = opts.merge({:origin => transcribe(@origin), :destination => transcribe(@destination)})
-
+    @options = begin
+      opts = @@default_options.merge opts
+      if opts[:coordinates]
+        opts.merge({:origin => @origin, :destination => @destination})
+      else
+        opts.merge({:origin => transcribe(@origin), :destination => transcribe(@destination)})
+      end
+    end 
+ 
     @url = @@base_url + '?' + @options.to_params
     @xml = open(@url).read
     @doc = Nokogiri::XML(@xml)


### PR DESCRIPTION
Transcribe seemed to be working incorrectly with commas in the coordinate style inputs.

I simply ignored it as a quick fix. Works.
