### PR TITLE
Added Event machine compatibility using httpi library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source :rubygems
 
+gem 'em-http-request'
+gem 'em-synchrony'
+
 gemspec


### PR DESCRIPTION
Added httpi library, and use that instead to make requests, as I can functionally choose the adapter by passing in the new use_em option with opts on initialize.
