### PR TITLE
Fix when Rails is present and to_query escape twice origin and destination params

### DIFF
--- a/google_directions.gemspec
+++ b/google_directions.gemspec
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+# stub: google_directions 0.1.6.2 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "google_directions"
+  s.version = "0.1.6.2"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.authors = ["Josh Crews"]
+  s.date = "2014-09-11"
+  s.description = "Ruby-wrapper for Google Directions API.  Can return the drive time and driving distance between to places"
+  s.email = "josh@joshcrews.com"
+  s.extra_rdoc_files = ["README.textile", "lib/google_directions.rb"]
+  s.files = ["Gemfile", "Gemfile.lock", "Manifest", "README.textile", "Rakefile", "google_directions.gemspec", "init.rb", "lib/google_directions.rb", "test/mocks/google_directions_samle_xml.xml", "test/test_helper.rb", "test/unit/google_directions_test.rb"]
+  s.homepage = "http://github.com/joshcrews/Google-Directions-Ruby"
+  s.rdoc_options = ["--line-numbers", "--title", "Google_directions", "--main", "README.textile"]
+  s.rubyforge_project = "google_directions"
+  s.rubygems_version = "2.2.0"
+  s.summary = "Ruby-wrapper for Google Directions API.  Can return the drive time and driving distance between to places"
+  s.test_files = ["test/test_helper.rb", "test/unit/google_directions_test.rb"]
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<nokogiri>, [">= 1.4.1"])
+    else
+      s.add_dependency(%q<nokogiri>, [">= 1.4.1"])
+    end
+  else
+    s.add_dependency(%q<nokogiri>, [">= 1.4.1"])
+  end
+end

--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -20,7 +20,7 @@ class GoogleDirections
   def initialize(origin, destination, opts=@@default_options)
     @origin = origin
     @destination = destination
-    @options = opts.merge({:origin => transcribe(@origin), :destination => transcribe(@destination)})
+    @options = opts.merge({:origin => @origin, :destination => @destination})
 
     @url = @@base_url + '?' + @options.to_query
     @xml = open(@url).read
@@ -90,11 +90,6 @@ class GoogleDirections
     def convert_to_minutes(text)
       (text.to_f / 60).round
     end
-
-    def transcribe(location)
-      CGI::escape(location)
-    end
-
 end
 
 class Hash

--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -96,7 +96,7 @@ class Hash
 
   def to_query
     collect do |k, v|
-      "#{k}=#{v}"
+      "#{k}=#{CGI::escape(v.to_s)}"
     end * '&'
   end unless method_defined? :to_query
 

--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -100,14 +100,9 @@ end
 class Hash
 
   def to_query
-    params = ''
-
-    each do |k, v|
-      params << "#{k}=#{v}&"
-    end
-
-    params.chop! # trailing &
-    params
+    collect do |k, v|
+      "#{k}=#{v}"
+    end * '&'
   end unless method_defined? :to_query
 
 end


### PR DESCRIPTION
Hi,

I did some refactoring in Hash#to_query based on Rails Hash#to_param and Object.to_query.
Before was escaping twice when using transcribe method and Object#to_query, now escape params one time in GoogleDirections Hash#to_query 
